### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You lose once blocks on a face of the hexagon stack outside of the outer hexagon
 
 * Official app website: <http://hextris.github.io/>
 * Upstream app code repository: <https://github.com/Hextris/Hextris>
-* YunoHost documentation for this app: <https://yunohost.org/app_hextris>
+* YunoHost Store: <https://apps.yunohost.org/app/hextris>
 * Report a bug: <https://github.com/YunoHost-Apps/hextris_ynh/issues>
 
 ## Developer info

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Destroying multiple series of blocks grants combos, whose durations are indicate
 You lose once blocks on a face of the hexagon stack outside of the outer hexagon!
 
 
-**Shipped version:** 2023.06.08~ynh1
+**Shipped version:** 2023.06.09~ynh1
 
 **Demo:** https://hextris.io/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,7 +25,7 @@ Détruire plusieurs séries de blocs permet d'obtenir des combos, dont la durée
 Vous perdez une fois les blocs sur une face de la pile hexagonale en dehors de l'hexagone extérieur !
 
 
-**Version incluse :** 2023.06.08~ynh1
+**Version incluse :** 2023.06.09~ynh1
 
 **Démo :** https://hextris.io/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -37,7 +37,7 @@ Vous perdez une fois les blocs sur une face de la pile hexagonale en dehors de l
 
 * Site officiel de l’app : <http://hextris.github.io/>
 * Dépôt de code officiel de l’app : <https://github.com/Hextris/Hextris>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_hextris>
+* YunoHost Store: <https://apps.yunohost.org/app/hextris>
 * Signaler un bug : <https://github.com/YunoHost-Apps/hextris_ynh/issues>
 
 ## Informations pour les développeurs

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Hextris"
 description.en = "Fast paced puzzle game"
 description.fr = "Jeu de puzzle très rapide"
 
-version = "2023.06.08~ynh1"
+version = "2023.06.09~ynh1"
 
 maintainers = ["AerisOne"]
 
@@ -39,8 +39,8 @@ ram.runtime = "50M"
 
 [resources]
         [resources.sources.main]
-        url = "https://github.com/Hextris/hextris/archive/8872ec47d694628e2fe668ebaa90b13d5626d95f.tar.gz"
-        sha256 = "67f3fbd54c405717a25fb1e6f71d2b46e94c7ac6971861dd99ae5e58f6609892"
+        url = "https://github.com/Hextris/hextris/archive/3f4847dc8fd7dab3d1c87e6324b9159d92fbd396.tar.gz"
+        sha256 = "38539c391cd97b1d90177c81b55a6194fd00e1b930bb21951d39b4902a4377ef"
         autoupdate.upstream = "https://github.com/Hextris/hextris"
         autoupdate.strategy = "latest_github_commit"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,7 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1
 fi
 
 chmod -R o-rwx "$install_dir"


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```